### PR TITLE
Fix configuration and imports

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -1,6 +1,7 @@
 import logging
 from pyrogram import Client, filters
 from config import API_ID, API_HASH, BOT_TOKEN, SESSION_NAME
+from plugins.controls import user as voice_user
 
 # Enable logging
 logging.basicConfig(level=logging.INFO)
@@ -29,4 +30,5 @@ for plugin in PLUGINS:
 # Start the Bot
 if __name__ == "__main__":
     LOGGER.info("🚀 PhiloTune Assistant Started Successfully!")
+    voice_user.start()
     app.run()

--- a/config.py
+++ b/config.py
@@ -9,6 +9,8 @@ API_ID = int(os.getenv("API_ID", "0"))
 API_HASH = os.getenv("API_HASH", "")
 BOT_TOKEN = os.getenv("BOT_TOKEN", "")
 SESSION_NAME = os.getenv("SESSION_NAME", "")
+OWNER_ID = int(os.getenv("OWNER_ID", "0"))
+SESSION_STRING = os.getenv("SESSION_STRING", "")
 
 MONGO_DB_URI = os.getenv("MONGO_DB_URI", "")
 REDIS_URI = os.getenv("REDIS_URI", "")

--- a/plugins/command.py
+++ b/plugins/command.py
@@ -1,6 +1,5 @@
 from pyrogram import Client, filters
 from config import OWNER_ID
-from queue import get_queue
 
 # Basic in-memory counters (extend with DB if needed)
 total_songs = 0

--- a/plugins/controls.py
+++ b/plugins/controls.py
@@ -4,8 +4,6 @@ from pytgcalls.types.input_stream import AudioPiped
 from pytgcalls.types.stream import StreamAudio
 from config import SESSION_STRING, API_ID, API_HASH
 from queue import skip_current, get_queue, is_active
-from utils.generate_card import generate_card
-import os
 
 user = Client("VCUser", session_string=SESSION_STRING, api_id=API_ID, api_hash=API_HASH)
 call = PyTgCalls(user)

--- a/plugins/play.py
+++ b/plugins/play.py
@@ -1,17 +1,13 @@
 from pyrogram import Client, filters
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-from pytgcalls import PyTgCalls
 from pytgcalls.types.stream import StreamAudio
 from pytgcalls.types.input_stream import AudioPiped
-from config import API_ID, API_HASH, BOT_TOKEN
-from utils.downloader import download_song
-from utils.generate_card import generate_card
+from .controls import user, call
+from .downloader import download_song
+from .generate_card import generate_card
 import os
 
-app = Client("MusicBot", api_id=API_ID, api_hash=API_HASH, bot_token=BOT_TOKEN)
-call = PyTgCalls(app)
-
-@app.on_message(filters.command("play"))
+@Client.on_message(filters.command("play"))
 async def play_music(client, message):
     chat_id = message.chat.id
     if len(message.command) < 2:
@@ -50,7 +46,7 @@ async def play_music(client, message):
     await call.start()
     await call.join_group_call(chat_id, audio, stream_type=StreamAudio())
 
-@app.on_callback_query()
+@Client.on_callback_query()
 async def handle_callbacks(client, callback_query):
     chat_id = callback_query.message.chat.id
     data = callback_query.data

--- a/queue.py
+++ b/queue.py
@@ -1,0 +1,21 @@
+queues = {}
+
+def get_queue(chat_id):
+    return queues.get(chat_id, [])
+
+
+def add_to_queue(chat_id, item):
+    q = queues.setdefault(chat_id, [])
+    q.append(item)
+
+
+def skip_current(chat_id):
+    q = queues.get(chat_id)
+    if q:
+        q.pop(0)
+        return q[0] if q else None
+    return None
+
+
+def is_active(chat_id):
+    return bool(queues.get(chat_id))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pymongo
 redis
 python-dotenv
 yt-dlp
-ffmpeg
 git+https://github.com/pytgcalls/pytgcalls.git
+Pillow


### PR DESCRIPTION
## Summary
- define missing OWNER_ID and SESSION_STRING in config
- add a simple queue helper
- fix plugin imports and reuse shared VC user
- start the voice user client on startup
- clean requirements for missing packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843163ddd88832ebc7b03fcd63664e5